### PR TITLE
Windows jenkins

### DIFF
--- a/condaci.py
+++ b/condaci.py
@@ -10,10 +10,6 @@ import uuid
 import sys
 from pprint import pprint
 
-# on windows we have to download a small secondary script that configures
-# Python 3 64-bit extensions. Here we define the URL and the local path that
-# we will use for this script.
-import zipfile
 
 VS9_PY_VERS = ['2.7']
 VS10_PY_VERS = ['3.3', '3.4']
@@ -130,14 +126,6 @@ def execute_sequence(*cmds, **kwargs):
     verbose = kwargs.get('verbose', True)
     for cmd in cmds:
         execute(cmd, verbose)
-
-
-def extract_zip(zip_path, dest_dir):
-    r"""
-    Extract a zip file to a destination
-    """
-    with zipfile.PyZipFile(str(zip_path)) as z:
-        z.extractall(path=str(dest_dir))
 
 
 def download_file(url, path_to_download):

--- a/condaci.py
+++ b/condaci.py
@@ -166,8 +166,8 @@ def url_for_platform_version(platform, py_version, arch):
     platform_str = {'Linux': 'Linux',
                     'Darwin': 'MacOSX',
                     'Windows': 'Windows'}
-    arch_str = {'64bit': 'x86_64',
-                '32bit': 'x86'}
+    arch_str = {'x64': 'x86_64',
+                'x86': 'x86'}
     ext = {'Linux': '.sh',
            'Darwin': '.sh',
            'Windows': '.exe'}
@@ -193,7 +193,7 @@ def appveyor_miniconda_dir():
     else:
         raise ValueError(SUPPORTED_ERR_MSG)
 
-    if python_arch() == '64bit':
+    if python_arch() == 'x64':
         conda_dir += '-x64'
 
     return conda_dir
@@ -315,7 +315,7 @@ def get_conda_build_path(recipe_dir):
 
 def windows_setup_compiler():
     arch = python_arch()
-    if PYTHON_VERSION in VS9_PY_VERS and arch == '64bit':
+    if PYTHON_VERSION in VS9_PY_VERS and arch == 'x64':
         VS2008_AMD64_PATH = os.path.join(VS2008_BIN_PATH, 'amd64')
         if not os.path.exists(VS2008_AMD64_PATH):
             os.makedirs(VS2008_AMD64_PATH)
@@ -325,7 +325,7 @@ def windows_setup_compiler():
                   VCVARS64_PATH, VCVARSAMD64_PATH))
         shutil.copyfile(VCVARS64_PATH, VCVARSAMD64_PATH)
     # Python 3.3 or 3.4
-    elif PYTHON_VERSION in VS10_PY_VERS and arch == '64bit':
+    elif PYTHON_VERSION in VS10_PY_VERS and arch == 'x64':
         VS2010_AMD64_PATH = os.path.join(VS2010_BIN_PATH, 'amd64')
         if not os.path.exists(VS2010_AMD64_PATH):
             os.makedirs(VS2010_AMD64_PATH)
@@ -690,7 +690,7 @@ def binstar_channel_from_ci(path):
 
 # pypirc_path = p.join(p.expanduser('~'), '.pypirc')
 # pypi_upload_allowed = (host_platform() == 'Linux' and
-#                        host_arch() == '64bit' and
+#                        host_arch() == 'x64' and
 #                        sys.version_info.major == 2)
 #
 # pypi_template = """[distutils]

--- a/condaci.py
+++ b/condaci.py
@@ -606,7 +606,8 @@ is_on_jenkins = lambda: 'JENKINS_URL' in os.environ
 
 is_pr_from_travis = lambda: os.environ['TRAVIS_PULL_REQUEST'] != 'false'
 is_pr_from_appveyor = lambda: 'APPVEYOR_PULL_REQUEST_NUMBER' in os.environ
-is_pr_from_jenkins = lambda: 'ghprbSourceBranch' in os.environ
+# TODO: Remove when ghprb is fixed
+is_pr_from_jenkins = os.environ['JOB_NAME'].split('/')[0][-3:] == '-pr'
 
 branch_from_appveyor = lambda: os.environ['APPVEYOR_REPO_BRANCH']
 

--- a/condaci.py
+++ b/condaci.py
@@ -265,7 +265,9 @@ def acquire_miniconda(url, path_to_download):
 def install_miniconda(path_to_installer, path_to_install):
     print('Installing miniconda to {}'.format(path_to_install))
     if is_windows():
-        execute([path_to_installer, '/S', '/D={}'.format(path_to_install)])
+        execute([path_to_installer, '/InstallationType=AllUsers',
+                 '/AddToPath=0', '/RegisterPath=1', '/NoRegistry=1',
+                 '/S', '/D={}'.format(path_to_install)])
     else:
         execute(['chmod', '+x', path_to_installer])
         execute([path_to_installer, '-b', '-p', path_to_install])

--- a/condaci.py
+++ b/condaci.py
@@ -607,7 +607,7 @@ is_on_jenkins = lambda: 'JENKINS_URL' in os.environ
 is_pr_from_travis = lambda: os.environ['TRAVIS_PULL_REQUEST'] != 'false'
 is_pr_from_appveyor = lambda: 'APPVEYOR_PULL_REQUEST_NUMBER' in os.environ
 # TODO: Remove when ghprb is fixed
-is_pr_from_jenkins = os.environ['JOB_NAME'].split('/')[0][-3:] == '-pr'
+is_pr_from_jenkins = lambda: os.environ['JOB_NAME'].split('/')[0][-3:] == '-pr'
 
 branch_from_appveyor = lambda: os.environ['APPVEYOR_REPO_BRANCH']
 

--- a/condaci.py
+++ b/condaci.py
@@ -217,7 +217,7 @@ def jenkins_windows_miniconda_dir():
 
 
 def temp_installer_path():
-    # we need a place to download the miniconda installer too. use a random
+    # we need a place to download the miniconda installer to. use a random
     # string for the filename to avoid collisions, but choose the dir based
     # on platform
     return ('C:\{}.exe'.format(RANDOM_UUID) if is_windows()
@@ -225,7 +225,7 @@ def temp_installer_path():
 
 
 def miniconda_dir():
-    # the directory where miniconda will be installed too/is
+    # the directory where miniconda will be installed to/is
     if is_on_appveyor():
         path = appveyor_miniconda_dir()
     elif is_on_travis():

--- a/condaci.py
+++ b/condaci.py
@@ -326,7 +326,8 @@ def windows_setup_compiler():
         VCVARS64_PATH = os.path.join(VS2008_BIN_PATH, 'vcvars64.bat')
         VCVARSAMD64_PATH = os.path.join(VS2008_AMD64_PATH, 'vcvarsamd64.bat')
         if not os.path.exists(VCVARS64_PATH):
-            print("Unable to find '{}' - skipping fix for VS2008 64-bit.")
+            print("Unable to find '{}' - skipping fix for VS2008 64-bit.".format(
+                VCVARS64_PATH))
         else:
             print("Copying '{}' to '{}' to fix VS2008 64-bit configuration.".format(
                       VCVARS64_PATH, VCVARSAMD64_PATH))

--- a/condaci.py
+++ b/condaci.py
@@ -325,9 +325,12 @@ def windows_setup_compiler():
             os.makedirs(VS2008_AMD64_PATH)
         VCVARS64_PATH = os.path.join(VS2008_BIN_PATH, 'vcvars64.bat')
         VCVARSAMD64_PATH = os.path.join(VS2008_AMD64_PATH, 'vcvarsamd64.bat')
-        print("Copying '{}' to '{}' to fix VS2008 64-bit configuration.".format(
-                  VCVARS64_PATH, VCVARSAMD64_PATH))
-        shutil.copyfile(VCVARS64_PATH, VCVARSAMD64_PATH)
+        if not os.path.exists(VCVARS64_PATH):
+            print("Unable to find '{}' - skipping fix for VS2008 64-bit.")
+        else:
+            print("Copying '{}' to '{}' to fix VS2008 64-bit configuration.".format(
+                      VCVARS64_PATH, VCVARSAMD64_PATH))
+            shutil.copyfile(VCVARS64_PATH, VCVARSAMD64_PATH)
     # Python 3.3 or 3.4
     elif PYTHON_VERSION in VS10_PY_VERS and ARCH == 'x64':
         VS2010_AMD64_PATH = os.path.join(VS2010_BIN_PATH, 'amd64')

--- a/condaci.py
+++ b/condaci.py
@@ -47,8 +47,9 @@ def set_globals_from_environ(verbose=True):
         raise ValueError('FATAL: Unknown CI system.')
 
     PYTHON_VERSION = os.environ.get('PYTHON_VERSION')
-    if 'ARCH' in os.environ:
-        ARCH = os.environ.get('ARCH')
+    # ARCH or PLATFORM - PLATFORM on Appveyor
+    if 'ARCH' in os.environ or 'PLATFORM' in os.environ:
+        ARCH = os.environ.get('ARCH', os.environ.get('PLATFORM'))
         arch_origin = 'Environment'
     else:
         # If we weren't given the ARCH variable (as on Jenkins) then predict


### PR DESCRIPTION
@jabooth I think this makes the necessary changes for Windows Jenkins.

Major change is that the miniconda executor path is now of the form:

`{MINICONDA_DIR}/{EXECUTOR_NUMBER}/{PYTHON_ARCH}`

rather than

`{MINICONDA_DIR}/{EXECUTOR_NUMBER}/{PYTHON_VER}`

because we don't actually care about the python versions and we do care about the python architecture, particularly on Windows. This also decreases the space taken up on the OSX Jenkins box.